### PR TITLE
disable grayskull inspection

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-bot:
-  inspection: disabled
 build_platform:
   linux_aarch64: linux_64
   osx_arm64: osx_64


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Grayskull incorrectly identifies zizmor as a Python/maturin package because the source tarball contains a `pyproject.toml` for Python bindings. This causes the autotick bot to fail with `KeyError: 'run'` when trying to apply dependency updates, since the recipe has no `run` section. See error logs in https://github.com/regro/cf-scripts/actions/runs/23081469923

The bot logs show:

```text
2026-03-14T05:46:21.7952059Z 2026-03-14 05:46:21,794 INFO     grayskull.base.github || Closest git reference to `1.23.1` is `v1.23.1`.
2026-03-14T05:46:32.7812349Z 2026-03-14 05:46:32,780 INFO     conda_forge_tick.update_deps || grayskull dep. comp: {'host': {'cf_minus_df': set(),
2026-03-14T05:46:32.7813310Z           'df_minus_cf': {'pip', 'python 3.10.*', 'maturin >=1.0,<2.0'}},
2026-03-14T05:46:32.7813947Z  'run': {'cf_minus_df': set(), 'df_minus_cf': {'python >=3.10'}}}
2026-03-14T05:46:32.7814847Z 2026-03-14 05:46:32,780 INFO     conda_forge_tick.migrators.dep_updates || applying deps: update-grayskull
2026-03-14T05:46:33.1364145Z 2026-03-14 05:46:33,134 ERROR    conda_forge_tick.auto_tick || NON GITHUB ERROR
2026-03-14T05:46:33.1365025Z Traceback (most recent call last):
2026-03-14T05:46:33.1365925Z   File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 830, in _run_migrator_on_feedstock_branch
2026-03-14T05:46:33.1366901Z     migrator_uid, pr_json = run_with_tmpdir(
2026-03-14T05:46:33.1367259Z                             ^^^^^^^^^^^^^^^^
2026-03-14T05:46:33.1367916Z   File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 514, in run_with_tmpdir
2026-03-14T05:46:33.1369202Z     return run(
2026-03-14T05:46:33.1369476Z            ^^^^
2026-03-14T05:46:33.1370180Z   File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 601, in run
2026-03-14T05:46:33.1370800Z     migration_run_data = run_migration(
2026-03-14T05:46:33.1371114Z                          ^^^^^^^^^^^^^^
2026-03-14T05:46:33.1371741Z   File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migration_runner.py", line 74, in run_migration
2026-03-14T05:46:33.1372303Z     return run_migration_containerized(
2026-03-14T05:46:33.1372540Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-03-14T05:46:33.1373342Z   File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migration_runner.py", line 175, in run_migration_containerized
2026-03-14T05:46:33.1374102Z     data = run_container_operation(
2026-03-14T05:46:33.1374343Z            ^^^^^^^^^^^^^^^^^^^^^^^^
2026-03-14T05:46:33.1374997Z   File "/home/runner/micromamba/envs/cf-scripts/lib/python3.12/site-packages/conda_forge_feedstock_ops/container_utils.py", line 231, in run_container_operation
2026-03-14T05:46:33.1375702Z     raise ContainerRuntimeError(
2026-03-14T05:46:33.1376694Z conda_forge_feedstock_ops.container_utils.ContainerRuntimeError: Error running 'conda-forge-tick-container migrate-feedstock --feedstock-name zizmor --default-branch main --existing-feedstock-node-attrs - --log-level info --kwargs {
2026-03-14T05:46:33.1377705Z   "hash_type": "sha256"
2026-03-14T05:46:33.1377935Z }' in container - error KeyError raised:
2026-03-14T05:46:33.1378506Z 'run'
```


Removing `bot.inspection` should fix this.
